### PR TITLE
update magic-string

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	},
 	"packageManager": "pnpm@7.13.0",
 	"dependencies": {
-		"magic-string": "^0.25.9",
+		"magic-string": "^0.27.0",
 		"svelte-parse-markup": "^0.1.1"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@types/node': ^18.11.10
-  magic-string: ^0.25.9
+  magic-string: ^0.27.0
   prettier: ^2.8.0
   prettier-plugin-svelte: ^2.8.1
   sass: ^1.56.1
@@ -15,7 +15,7 @@ specifiers:
   uvu: ^0.5.6
 
 dependencies:
-  magic-string: 0.25.9
+  magic-string: 0.27.0
   svelte-parse-markup: 0.1.1_svelte@3.53.1
 
 devDependencies:
@@ -49,6 +49,10 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /@jridgewell/sourcemap-codec/1.4.14:
+    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: false
 
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -616,6 +620,14 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
+    dev: true
+
+  /magic-string/0.27.0:
+    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.14
+    dev: false
 
   /merge-stream/2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -883,6 +895,7 @@ packages:
 
   /sourcemap-codec/1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    dev: true
 
   /strip-final-newline/2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}


### PR DESCRIPTION
I was getting deprecation warnings installing this package because the old version of `magic-string` depended on `sourcemap-codec` which was deprecated in favor of `@jridgewell/sourcemap-codec`. I'm not sure why npm didn't just get the newest version of `magic-string` given the sem ver range, but this should fix it regardless