### PR TITLE
chore: remove usage of soon to be deprecated method

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	},
 	"packageManager": "pnpm@8.6.3",
 	"dependencies": {
+		"estree-walker": "^3.0.3",
 		"magic-string": "^0.30.0",
 		"svelte-parse-markup": "^0.1.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  estree-walker:
+    specifier: ^3.0.3
+    version: 3.0.3
   magic-string:
     specifier: ^0.30.0
     version: 0.30.0

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import MagicString from 'magic-string'
+import { walk } from 'estree-walker'
 import { parse } from 'svelte-parse-markup'
-import { walk } from 'svelte/compiler'
 import {
   DEFAULT_SOURCES,
   DEFAULT_ASSET_PREFIX,


### PR DESCRIPTION
this is going away in Svelte 5 and will probably be deprecated in an upcoming Svelte 4 release